### PR TITLE
Add webpacker:compile to blacklisted tasks

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -238,7 +238,8 @@ module NewRelic
         'test:uncommitted',
         'time:zones:all',
         'tmp:clear',
-        'tmp:create'
+        'tmp:create',
+        'webpacker:compile'
       ].join(',').freeze
 
       DEFAULTS = {


### PR DESCRIPTION
Webpacker ships with Rails 5 and the task of compiling assets with webpack is pretty common.
Just like `assets:precompile` is a member of `AUTOSTART_BLACKLISTED_RAKE_TASKS`,
I suggest that `webpacker:compile` should be as well to avoid this:

<img width="556" alt="screen shot 2018-02-28 at 2 36 21 pm" src="https://user-images.githubusercontent.com/10076/36817089-c7db51ac-1c94-11e8-97b8-da90f7f70c30.png">
